### PR TITLE
Implement download cancellation and handle file name conflicts

### DIFF
--- a/SaveHere.WebAPI/Controllers/FileDownloadQueueItemsController.cs
+++ b/SaveHere.WebAPI/Controllers/FileDownloadQueueItemsController.cs
@@ -244,9 +244,9 @@ public class FileDownloadQueueItemsController : ControllerBase
         // Ignore progress reporting when the ContentLength's header is not available
         if (!contentLength.HasValue)
         {
-          await download.CopyToAsync(stream);
+          await download.CopyToAsync(stream, cancellationToken);
           queueItem.ProgressPercentage = 100;
-          await _context.SaveChangesAsync();
+          await _context.SaveChangesAsync(cancellationToken);
         }
         else
         {

--- a/SaveHere.WebAPI/Models/FileDownloadQueueItem.cs
+++ b/SaveHere.WebAPI/Models/FileDownloadQueueItem.cs
@@ -18,6 +18,7 @@ namespace SaveHere.WebAPI.Models
   {
     Paused,
     Downloading,
-    Finished
+    Finished,
+    Cancelled
   }
 }


### PR DESCRIPTION
- Implemented functionality in the back-end to allow users to cancel ongoing downloads ( see issue #11 ).
- Added a check to ensure unique file names by appending a digit to the file name if a file with the same name already exists in the destination directory.