### PR TITLE
Add maximum download speed (bytes per second) for direct downloader

### DIFF
--- a/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
@@ -52,6 +52,20 @@
                        Margin="Margin.Dense" />
     </MudStack>
 
+     <MudStack id="my-mudstack-row-1" Row>
+      <MudCheckBox @bind-Value="_autoStartPausedDownloads"
+                   Label="Add speed limit to download"
+                   Color="Color.Primary"
+                   T="bool" />
+
+      <MudNumericField @bind-Value="_maxBytesPerSecond"
+                       Label=""
+                       HelperText="Speed limit(Maximum bytes per second)"
+                       Min="10000"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense" />
+    </MudStack>
+
     <MudStack id="my-mudstack-row-1" Row Class="mt-3">
       <MudTextField @bind-Value="DownloadFolderName"
                     Label="Download Folder Name (Optional)"
@@ -183,6 +197,7 @@
 
     private bool _autoStartPausedDownloads = true;
     private int _maxAutoStartConcurrency = 3;
+    private int _maxBytesPerSecond = 500000;
 
     protected override async Task OnInitializedAsync()
     {
@@ -389,7 +404,7 @@
     {
       try
       {
-        var newFileDownload = new FileDownloadQueueItem() { InputUrl = UrlText, DownloadFolder = DownloadFolderName };
+        var newFileDownload = new FileDownloadQueueItem() { InputUrl = UrlText, MaxBytesPerSecond=_maxBytesPerSecond ,DownloadFolder = DownloadFolderName };
         _context.FileDownloadQueueItems.Add(newFileDownload);
         await _context.SaveChangesAsync();
 

--- a/SaveHere/SaveHere/Migrations/20250306200212_InitialCreate.cs
+++ b/SaveHere/SaveHere/Migrations/20250306200212_InitialCreate.cs
@@ -58,6 +58,7 @@ namespace SaveHere.Migrations
                   .Annotation("Sqlite:Autoincrement", true),
             InputUrl = table.Column<string>(type: "TEXT", nullable: false),
             Status = table.Column<int>(type: "INTEGER", nullable: false),
+            MaxBytesPerSecond = table.Column<int>(type: "INTEGER", nullable: false),
             ProgressPercentage = table.Column<int>(type: "INTEGER", nullable: false),
             bShowMoreOptions = table.Column<bool>(type: "INTEGER", nullable: false),
             bShouldGetFilenameFromHttpHeaders = table.Column<bool>(type: "INTEGER", nullable: false),

--- a/SaveHere/SaveHere/Migrations/AppDbContextModelSnapshot.cs
+++ b/SaveHere/SaveHere/Migrations/AppDbContextModelSnapshot.cs
@@ -234,6 +234,9 @@ namespace SaveHere.Migrations
             b.Property<int>("ProgressPercentage")
                       .HasColumnType("INTEGER");
 
+            b.Property<int>("MaxBytesPerSecond")
+                       .HasColumnType("INTEGER");
+
             b.Property<int>("Status")
                       .HasColumnType("INTEGER");
 

--- a/SaveHere/SaveHere/Models/FileDownloadQueueItem.cs
+++ b/SaveHere/SaveHere/Models/FileDownloadQueueItem.cs
@@ -14,14 +14,11 @@ namespace SaveHere.Models
     public EQueueItemStatus Status { get; set; } = EQueueItemStatus.Paused;
 
     public int ProgressPercentage { get; set; } = 0;
-
+    public int MaxBytesPerSecond { get; set; } = 50000;
     public bool bShowMoreOptions { get; set; } = false;
-
     public bool bShouldGetFilenameFromHttpHeaders { get; set; } = true;
-
     public double CurrentDownloadSpeed { get; set; } = 0;
     public double AverageDownloadSpeed { get; set; } = 0;
-
     public string? DownloadFolder { get; set; }
   }
 }

--- a/SaveHere/SaveHere/Services/DownloadQueueService.cs
+++ b/SaveHere/SaveHere/Services/DownloadQueueService.cs
@@ -333,6 +333,8 @@ namespace SaveHere.Services
             await _progressHubService.BroadcastProgressUpdate(downloadProgress);
           }
 
+          double timePerReadInMilliseconds = 1000.0 / queueItem.MaxBytesPerSecond * buffer.Length;
+
           // when we don't know the file size
           if (!contentLength.HasValue)
           {
@@ -345,6 +347,7 @@ namespace SaveHere.Services
               }
 
               await stream.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+              await Task.Delay((int)timePerReadInMilliseconds);
               totalBytesRead += bytesRead;
               bytesReadInLastPeriod += bytesRead;
               bytesReadInTotal += bytesRead;
@@ -373,6 +376,7 @@ namespace SaveHere.Services
               }
 
               await stream.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+              await Task.Delay((int)timePerReadInMilliseconds);
               totalBytesRead += bytesRead;
               bytesReadInLastPeriod += bytesRead;
               bytesReadInTotal += bytesRead;


### PR DESCRIPTION
In the direct downloader i have added the option to specify how many byter per second at max can be downloaded,

![image](https://github.com/user-attachments/assets/cc05b8ba-a854-43a6-b96d-bf94dfd4ded3)
