### PR TITLE
Update User-specific folder for 2 download options

### DIFF
--- a/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
@@ -9,6 +9,7 @@
 @using System.Net
 @using System.Diagnostics
 @using Microsoft.AspNetCore.SignalR.Client
+@using System.Security.Claims 
 
 @rendermode InteractiveServer
 @attribute [StreamRendering]
@@ -234,7 +235,7 @@
   private string UrlText { get; set; } = "";
   private string ErrorMessage { get; set; } = "";
 
-  private string? DownloadFolderName { get; set; }
+  private string? DownloadFolderName { get; set; } = null;
 
   private List<FileDownloadQueueItem> _fileDownloadQueueItems = new();
   private bool _isLoadingTheList = false;
@@ -262,7 +263,7 @@
   protected override async Task OnInitializedAsync()
   {
     var authState = await AuthProvider.GetAuthenticationStateAsync();
-    userId = authState.User.Identity?.Name ?? "anonymous";
+    userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "anonymous";
     userFolderPath = DirectoryBrowser.GetUserDownloadsPath(userId);
     DownloadFolderName = userId;
     persistingSubscription = _persistentState.RegisterOnPersisting(PersistItems);
@@ -477,8 +478,8 @@
       {
         int mbs = _maxBytesPerSecond;
         if (!_useMaxDownloadSpeedLimit) mbs = -1;
-
-        var newFileDownload = new FileDownloadQueueItem() { InputUrl = UrlText, MaxBytesPerSecond = mbs, DownloadFolder = DownloadFolderName };
+        var validatedFolder = ValidateUserDownloadFolder(DownloadFolderName);
+        var newFileDownload = new FileDownloadQueueItem() { InputUrl = UrlText, MaxBytesPerSecond = mbs, DownloadFolder = validatedFolder };
         _context.FileDownloadQueueItems.Add(newFileDownload);
         await _context.SaveChangesAsync();
 
@@ -507,7 +508,8 @@
   {
     try
     {
-      await DownloadQueueService.StartDownloadAsync(item.Id, DownloadFolderName);
+      var validatedFolder = ValidateUserDownloadFolder(DownloadFolderName);
+      await DownloadQueueService.StartDownloadAsync(item.Id, validatedFolder);
     }
     catch (Exception exception)
     {
@@ -655,5 +657,17 @@
           Data = item.SpeedHistory.Select(s => Math.Round(s / 1024 / 1024, 2)).ToArray()
         }
       };
+  }
+  private string ValidateUserDownloadFolder(string? folder)
+  {
+    if (string.IsNullOrWhiteSpace(folder))
+      return userFolderPath;
+
+    var combinedPath = Path.GetFullPath(Path.Combine(userFolderPath, folder));
+
+    if (!combinedPath.StartsWith(userFolderPath, StringComparison.OrdinalIgnoreCase))
+      throw new InvalidOperationException("Invalid folder path.");
+
+    return combinedPath;
   }
 }

--- a/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
@@ -12,6 +12,7 @@
 
 @rendermode InteractiveServer
 @attribute [StreamRendering]
+@inject AuthenticationStateProvider AuthProvider
 
 <MudPopoverProvider />
 <MudDialogProvider />
@@ -212,7 +213,7 @@
     </MudPaper>
   }
 
-  <FileManager @ref="fileManager" />
+  <FileManager UserId="@userId" CurrentPath="@userFolderPath" @ref="fileManager" />
 </LoadingIndicator>
 
 @code {
@@ -244,7 +245,8 @@
   private bool _useMaxDownloadSpeedLimit = false;
   private int _maxAutoStartConcurrency = 3;
   private int _maxBytesPerSecond = -1;
-
+  private string userId { get; set; } = "";
+  private string userFolderPath { get; set; } = string.Empty;
   private readonly ChartOptions _chartOptions = new()
   {
     LineStrokeWidth = 3,
@@ -259,6 +261,10 @@
 
   protected override async Task OnInitializedAsync()
   {
+    var authState = await AuthProvider.GetAuthenticationStateAsync();
+    userId = authState.User.Identity?.Name ?? "anonymous";
+    userFolderPath = DirectoryBrowser.GetUserDownloadsPath(userId);
+    DownloadFolderName = userId;
     persistingSubscription = _persistentState.RegisterOnPersisting(PersistItems);
 
     // Loading downloads list

--- a/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
@@ -248,7 +248,8 @@
 
   private string UrlText { get; set; } = "";
   private string ErrorMessage { get; set; } = "";
-
+  
+  private string? CustomFileName { get; set; }
   private string? DownloadFolderName { get; set; } = null;
 
   private List<FileDownloadQueueItem> _fileDownloadQueueItems = new();
@@ -493,7 +494,7 @@
         int mbs = _maxBytesPerSecond;
         if (!_useMaxDownloadSpeedLimit) mbs = -1;
         var validatedFolder = ValidateUserDownloadFolder(DownloadFolderName);
-        var newFileDownload = new FileDownloadQueueItem() { InputUrl = UrlText, MaxBytesPerSecond = mbs, DownloadFolder = validatedFolder };
+        var newFileDownload = new FileDownloadQueueItem() { InputUrl = UrlText, CustomFileName = CustomFileName, MaxBytesPerSecond = mbs, DownloadFolder = validatedFolder };
 
         _context.FileDownloadQueueItems.Add(newFileDownload);
         await _context.SaveChangesAsync();
@@ -524,7 +525,7 @@
     try
     {
       var validatedFolder = ValidateUserDownloadFolder(DownloadFolderName);
-      await DownloadQueueService.StartDownloadAsync(item.Id, validatedFolder);
+      await DownloadQueueService.StartDownloadAsync(item.Id, CustomFileName, validatedFolder);
 
     }
     catch (Exception exception)

--- a/SaveHere/SaveHere/Components/Download/DownloadVideoAudio.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadVideoAudio.razor
@@ -231,7 +231,7 @@
     private string ProxyUrl { get; set; } = @"http://localhost:8086";
     private string SelectedQuality { get; set; } = "Best";
     private string ErrorMessage { get; set; } = "";
-
+    private string? CustomFileName { get; set; }
     private string? DownloadFolderName { get; set; } = null;
 
     private List<YoutubeDownloadQueueItem> _youtubeDownloadQueueItems = new();
@@ -402,7 +402,7 @@
         try
         {
             var validatedFolder = ValidateUserDownloadFolder(DownloadFolderName);
-            var newYoutubeDownload = await YoutubeDownloadQueueService.AddQueueItemAsync(YoutubeUrl, SelectedQuality, ProxyUrl, DownloadFolderName);
+            var newYoutubeDownload = await YoutubeDownloadQueueService.AddQueueItemAsync(YoutubeUrl,CustomFileName, SelectedQuality, ProxyUrl, DownloadFolderName);
 
             YoutubeUrl = "";
             ErrorMessage = "";
@@ -427,7 +427,7 @@
             item.Quality = SelectedQuality;
             item.Proxy = ProxyUrl;
             item.DownloadFolder = ValidateUserDownloadFolder(DownloadFolderName);
-
+            item.CustomFileName = CustomFileName;
             await YoutubeDownloadQueueService.StartDownloadAsync(item);
         }
         catch (Exception exception)

--- a/SaveHere/SaveHere/Components/Download/DownloadVideoAudio.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadVideoAudio.razor
@@ -7,6 +7,7 @@
 @using SaveHere.Services
 @using System.Net
 @using Microsoft.AspNetCore.SignalR.Client
+@using SaveHere.Helpers
 
 @inject AppDbContext _context
 @inject PersistentComponentState _persistentState
@@ -15,6 +16,7 @@
 @inject IYtdlpService YtdlpService
 @inject IYoutubeDownloadQueueService YoutubeDownloadQueueService
 @inject IDialogService DialogService
+@inject AuthenticationStateProvider AuthProvider
 
 @rendermode InteractiveServer
 @attribute [StreamRendering]
@@ -199,7 +201,7 @@
         }
     }
 
-    <FileManager @ref="fileManager" />
+    <FileManager UserId="@userId" CurrentPath="@userFolderPath" @ref="fileManager" />
 </LoadingIndicator>
 
 @code {
@@ -207,6 +209,8 @@
     private bool _isFullyLoaded;
     private PersistingComponentStateSubscription persistingSubscription;
     private HubConnection? hubConnection;
+    private string userId { get; set; } =  "";
+    private string userFolderPath { get; set; } = string.Empty;
 
     private string YoutubeUrl { get; set; } = "";
     private string ProxyUrl { get; set; } = @"http://localhost:8086";
@@ -227,6 +231,12 @@
     protected override async Task OnInitializedAsync()
     {
         persistingSubscription = _persistentState.RegisterOnPersisting(PersistItems);
+
+        // Retrieve the user ID from the authentication state
+        var authState = await AuthProvider.GetAuthenticationStateAsync();
+        userId = authState.User.Identity?.Name ?? "anonymous";
+        userFolderPath = DirectoryBrowser.GetUserDownloadsPath(userId);
+        DownloadFolderName = userId;
 
         // Loading downloads list
         if (_persistentState.TryTakeFromJson<List<YoutubeDownloadQueueItem>>(nameof(_youtubeDownloadQueueItems), out var savedItems) && savedItems != null)

--- a/SaveHere/SaveHere/Components/Download/DownloadVideoAudio.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadVideoAudio.razor
@@ -8,6 +8,7 @@
 @using System.Net
 @using Microsoft.AspNetCore.SignalR.Client
 @using SaveHere.Helpers
+@using System.Security.Claims
 
 @inject AppDbContext _context
 @inject PersistentComponentState _persistentState
@@ -217,7 +218,7 @@
     private string SelectedQuality { get; set; } = "Best";
     private string ErrorMessage { get; set; } = "";
 
-    private string? DownloadFolderName { get; set; }
+    private string? DownloadFolderName { get; set; } = null;
 
     private List<YoutubeDownloadQueueItem> _youtubeDownloadQueueItems = new();
     private bool _isLoadingTheList = false;
@@ -234,7 +235,7 @@
 
         // Retrieve the user ID from the authentication state
         var authState = await AuthProvider.GetAuthenticationStateAsync();
-        userId = authState.User.Identity?.Name ?? "anonymous";
+        userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "anonymous";
         userFolderPath = DirectoryBrowser.GetUserDownloadsPath(userId);
         DownloadFolderName = userId;
 
@@ -386,6 +387,7 @@
 
         try
         {
+            var validatedFolder = ValidateUserDownloadFolder(DownloadFolderName);
             var newYoutubeDownload = await YoutubeDownloadQueueService.AddQueueItemAsync(YoutubeUrl, SelectedQuality, ProxyUrl, DownloadFolderName);
             YoutubeUrl = "";
             ErrorMessage = "";
@@ -409,7 +411,7 @@
         {
             item.Quality = SelectedQuality;
             item.Proxy = ProxyUrl;
-            item.DownloadFolder = DownloadFolderName;
+            item.DownloadFolder = ValidateUserDownloadFolder(DownloadFolderName);
             await YoutubeDownloadQueueService.StartDownloadAsync(item);
         }
         catch (Exception exception)
@@ -562,6 +564,18 @@
         Console.WriteLine($"Error autostarting download '{item.Url}': {ex.Message}");
       }
     }
+  }
+  private string ValidateUserDownloadFolder(string? folder)
+  {
+    if (string.IsNullOrWhiteSpace(folder))
+      return userFolderPath;
+
+    var combinedPath = Path.GetFullPath(Path.Combine(userFolderPath, folder));
+
+    if (!combinedPath.StartsWith(userFolderPath, StringComparison.OrdinalIgnoreCase))
+      throw new InvalidOperationException("Invalid folder path.");
+
+    return combinedPath;
   }
 
 }

--- a/SaveHere/SaveHere/Components/Utility/FileManager.razor
+++ b/SaveHere/SaveHere/Components/Utility/FileManager.razor
@@ -152,8 +152,9 @@
   [Parameter] public EventCallback OnFilesChanged { get; set; }
 
   [Parameter] public string? CurrentPath { get; set; }
-
-  private string _currentDirectory = DirectoryBrowser.DownloadsPath;
+  [Parameter] public string? UserId { get; set; }
+  private string _userRootPath = string.Empty;
+  private string _currentDirectory = string.Empty;
 
   private HashSet<FileSystemItem> SelectedItems = new HashSet<FileSystemItem>();
 
@@ -163,10 +164,13 @@
   {
     if (AutoLoad)
     {
-      if (!string.IsNullOrEmpty(CurrentPath))
+      if (string.IsNullOrEmpty(UserId))
       {
-        _currentDirectory = CurrentPath;
+        errorMessage = "User ID is required.";
+        return;
       }
+      _userRootPath = DirectoryBrowser.GetUserDownloadsPath(UserId);
+      _currentDirectory = !string.IsNullOrEmpty(CurrentPath) ? CurrentPath : _userRootPath;
       await LoadFiles();
       UpdateBreadcrumbs();
     }
@@ -204,10 +208,10 @@
   private void UpdateBreadcrumbs()
   {
     breadcrumbsItems.Clear();
-    var pathParts = _currentDirectory.Substring(DirectoryBrowser.DownloadsPath.Length).Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
-    string currentPath = DirectoryBrowser.DownloadsPath;
+    var pathParts = _currentDirectory.Substring(_userRootPath.Length).Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+    string currentPath = _userRootPath;
 
-    breadcrumbsItems.Add(new BreadcrumbItem("Downloads", href: currentPath, disabled: true));
+    breadcrumbsItems.Add(new BreadcrumbItem($"{UserId}", href: currentPath, disabled: true));
 
     foreach (var part in pathParts)
     {
@@ -219,7 +223,7 @@
 
   private async Task NavigateToDirectory(string? path)
   {
-    if (path is null) path = DirectoryBrowser.DownloadsPath;
+    if (path is null) path = _userRootPath;
     _currentDirectory = path;
     await LoadFiles();
     UpdateBreadcrumbs();

--- a/SaveHere/SaveHere/Helpers/DirectoryBrowser.cs
+++ b/SaveHere/SaveHere/Helpers/DirectoryBrowser.cs
@@ -166,6 +166,22 @@
       }
     }
 
+    public static string GetUserDownloadsPath(string userId)
+    {
+        if (string.IsNullOrEmpty(userId))
+            throw new ArgumentException("User ID cannot be null or empty.", nameof(userId));
+
+        // Always build on top of the original root, not _downloadsPath
+        var rootPath = Path.Combine(Directory.GetCurrentDirectory(), "downloads");
+        var userDownloadsPath = Path.Combine(rootPath, userId);
+
+        if (!Directory.Exists(userDownloadsPath))
+        {
+            Directory.CreateDirectory(userDownloadsPath);
+        }
+
+        return userDownloadsPath;
+    }
   }
 
   public class FileSystemItem


### PR DESCRIPTION
- Updated breadcrumb generation to use a relative path based on the user's download root.
- Fixed default path resolution in FileManager to always reference the user's scoped folder under the downloads directory.