### PR TITLE
Fix UI unresponsiveness during downloads (Issue #54)

### DIFF
--- a/SaveHere/SaveHere.Tests/Integration/Http2IntegrationTests.cs
+++ b/SaveHere/SaveHere.Tests/Integration/Http2IntegrationTests.cs
@@ -46,22 +46,14 @@ namespace SaveHere.Tests.Integration
         }
 
         [Fact]
-        public async Task HttpClient_ShouldSupportCompression()
+        public void HttpClient_ShouldSupportCompression()
         {
-            // Arrange
-            using var scope = _factory.Services.CreateScope();
-            var httpClientFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
-            var httpClient = httpClientFactory.CreateClient();
-
-            // Create a test server that supports compression
+            // Arrange - Create a test handler that simulates compression support
             var testHandler = new TestHttpMessageHandler();
-            var testClient = new HttpClient(testHandler);
+            using var testClient = new HttpClient(testHandler);
 
             // Act & Assert
-            // The configured client should accept compressed responses
-            var request = new HttpRequestMessage(HttpMethod.Get, "http://test.com");
-
-            // Check if Accept-Encoding headers would be set (this is handled by the handler)
+            // The test handler is configured to support compression
             // In a real scenario, the AutomaticDecompression property handles this
             Assert.True(testHandler.SupportsCompression);
         }

--- a/SaveHere/SaveHere.Tests/Services/FileManagerServiceTests.cs
+++ b/SaveHere/SaveHere.Tests/Services/FileManagerServiceTests.cs
@@ -164,8 +164,9 @@ namespace SaveHere.Tests.Services
                 Type = "file"
             };
 
-            // Act
-            var result = _fileManagerService.RenameItem(fileItem, "invalid<>name.txt");
+            // Act - Use a filename with path separator which is invalid on all platforms
+            // (forward slash is a path separator on Linux/macOS, not allowed in filenames)
+            var result = _fileManagerService.RenameItem(fileItem, "invalid/name.txt");
 
             // Assert
             Assert.False(result);

--- a/SaveHere/SaveHere.Tests/Services/YoutubeDownloadQueueServiceTests.cs
+++ b/SaveHere/SaveHere.Tests/Services/YoutubeDownloadQueueServiceTests.cs
@@ -1,0 +1,605 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SaveHere.Models;
+using SaveHere.Models.db;
+using SaveHere.Models.SaveHere.Models;
+using SaveHere.Services;
+using Xunit;
+
+namespace SaveHere.Tests.Services
+{
+    public class YoutubeDownloadQueueServiceTests : IDisposable
+    {
+        private readonly Mock<IDbContextFactory<AppDbContext>> _contextFactoryMock;
+        private readonly DownloadStateService _downloadStateService;
+        private readonly Mock<ILogger<YoutubeDownloadQueueService>> _loggerMock;
+        private readonly Mock<IProgressHubService> _progressHubServiceMock;
+        private readonly Mock<IYtdlpService> _ytdlpServiceMock;
+        private readonly YoutubeDownloadQueueService _service;
+        private readonly DbContextOptions<AppDbContext> _options;
+        private readonly string _databaseName;
+
+        public YoutubeDownloadQueueServiceTests()
+        {
+            _databaseName = Guid.NewGuid().ToString();
+            _options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseInMemoryDatabase(databaseName: _databaseName)
+                .Options;
+
+            _contextFactoryMock = new Mock<IDbContextFactory<AppDbContext>>();
+            _contextFactoryMock.Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new AppDbContext(_options));
+
+            _downloadStateService = new DownloadStateService();
+            _loggerMock = new Mock<ILogger<YoutubeDownloadQueueService>>();
+            _progressHubServiceMock = new Mock<IProgressHubService>();
+            _ytdlpServiceMock = new Mock<IYtdlpService>();
+
+            _service = new YoutubeDownloadQueueService(
+                _contextFactoryMock.Object,
+                _downloadStateService,
+                _loggerMock.Object,
+                _progressHubServiceMock.Object,
+                _ytdlpServiceMock.Object);
+        }
+
+        public void Dispose()
+        {
+            // Clean up in-memory database
+        }
+
+        #region Basic CRUD Tests
+
+        [Fact]
+        public async Task AddQueueItemAsync_WithValidUrl_AddsItemToQueue()
+        {
+            // Arrange
+            var url = "https://www.youtube.com/watch?v=test123";
+
+            // Act
+            var result = await _service.AddQueueItemAsync(url, null, "best", "http://proxy:8080", null, null);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Url.Should().Be(url);
+            result.Status.Should().Be(EQueueItemStatus.Paused);
+            result.Quality.Should().Be("best");
+            result.Proxy.Should().Be("http://proxy:8080");
+
+            // Verify the item was saved
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(result.Id);
+            itemInDb.Should().NotBeNull();
+            itemInDb!.Url.Should().Be(url);
+        }
+
+        [Fact]
+        public async Task AddQueueItemAsync_WithEmptyUrl_ThrowsArgumentException()
+        {
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                _service.AddQueueItemAsync("", null, "best", "", null, null));
+        }
+
+        [Fact]
+        public async Task AddQueueItemAsync_WithInvalidUrl_ThrowsArgumentException()
+        {
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                _service.AddQueueItemAsync("not-a-valid-url", null, "best", "", null, null));
+        }
+
+        [Fact]
+        public async Task GetQueueItemsAsync_ReturnsAllItems()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var items = new List<YoutubeDownloadQueueItem>
+                {
+                    new() { Id = 1, Url = "https://youtube.com/watch?v=1", Quality = "best", Proxy = "", Status = EQueueItemStatus.Paused },
+                    new() { Id = 2, Url = "https://youtube.com/watch?v=2", Quality = "best", Proxy = "", Status = EQueueItemStatus.Downloading }
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddRangeAsync(items);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act
+            var result = await _service.GetQueueItemsAsync();
+
+            // Assert
+            result.Should().HaveCount(2);
+            result.Should().Contain(item => item.Id == 1);
+            result.Should().Contain(item => item.Id == 2);
+        }
+
+        [Fact]
+        public async Task GetQueueItemByIdAsync_WithValidId_ReturnsItem()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Paused
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act
+            var result = await _service.GetQueueItemByIdAsync(1);
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.Id.Should().Be(1);
+            result.Url.Should().Be("https://youtube.com/watch?v=test");
+        }
+
+        [Fact]
+        public async Task GetQueueItemByIdAsync_WithInvalidId_ReturnsNull()
+        {
+            // Act
+            var result = await _service.GetQueueItemByIdAsync(999);
+
+            // Assert
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task DeleteQueueItemAsync_WithValidId_RemovesItem()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Paused
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act
+            await _service.DeleteQueueItemAsync(1);
+
+            // Assert
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+            itemInDb.Should().BeNull();
+        }
+
+        #endregion
+
+        #region Log Batching Tests
+
+        [Fact]
+        public async Task AppendLogAsync_AddsLogToQueue_WithoutImmediateDbWrite()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Downloading,
+                    PersistedLog = ""
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act - Append a single log line (should not trigger immediate DB write due to batching)
+            await _service.AppendLogAsync(1, "Test log line 1");
+
+            // Assert - The log should be queued but not immediately persisted
+            // (The first append within the flush interval doesn't trigger a flush)
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            // The log might not be persisted yet due to batching (5 second interval)
+            // This verifies the batching mechanism is working
+            itemInDb.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task AppendLogAsync_MultipleLogs_AreBatchedTogether()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Downloading,
+                    PersistedLog = ""
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act - Append multiple logs rapidly
+            await _service.AppendLogAsync(1, "Log line 1");
+            await _service.AppendLogAsync(1, "Log line 2");
+            await _service.AppendLogAsync(1, "Log line 3");
+
+            // Force flush to persist logs
+            await _service.FlushLogsAsync(1);
+
+            // Assert - All logs should be persisted together
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            itemInDb.Should().NotBeNull();
+            itemInDb!.PersistedLog.Should().Contain("Log line 1");
+            itemInDb.PersistedLog.Should().Contain("Log line 2");
+            itemInDb.PersistedLog.Should().Contain("Log line 3");
+        }
+
+        [Fact]
+        public async Task FlushLogsAsync_PersistsAllPendingLogs()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Downloading,
+                    PersistedLog = ""
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act - Add logs and flush
+            await _service.AppendLogAsync(1, "First log");
+            await _service.AppendLogAsync(1, "Second log");
+            await _service.FlushLogsAsync(1);
+
+            // Assert
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            itemInDb.Should().NotBeNull();
+            itemInDb!.PersistedLog.Should().NotBeNullOrEmpty();
+
+            var logLines = itemInDb.PersistedLog.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            logLines.Should().Contain("First log");
+            logLines.Should().Contain("Second log");
+        }
+
+        [Fact]
+        public async Task FlushLogsAsync_WithNoLogs_DoesNothing()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Downloading,
+                    PersistedLog = "Existing log"
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act - Flush without any pending logs
+            await _service.FlushLogsAsync(1);
+
+            // Assert - Existing log should remain unchanged
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            itemInDb.Should().NotBeNull();
+            itemInDb!.PersistedLog.Should().Be("Existing log");
+        }
+
+        [Fact]
+        public async Task FlushLogsAsync_WithNonExistentItem_DoesNotThrow()
+        {
+            // Act & Assert - Should not throw for non-existent item
+            await _service.FlushLogsAsync(999);
+        }
+
+        [Fact]
+        public async Task AppendLogAsync_AppendsToExistingLogs()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Downloading,
+                    PersistedLog = "Existing log line"
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act - Append new log and flush
+            await _service.AppendLogAsync(1, "New log line");
+            await _service.FlushLogsAsync(1);
+
+            // Assert
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            itemInDb.Should().NotBeNull();
+            itemInDb!.PersistedLog.Should().Contain("Existing log line");
+            itemInDb.PersistedLog.Should().Contain("New log line");
+        }
+
+        [Fact]
+        public async Task AppendLogAsync_ConcurrentAppends_AreHandledSafely()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Downloading,
+                    PersistedLog = ""
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act - Simulate concurrent log appends
+            var tasks = Enumerable.Range(1, 100)
+                .Select(i => _service.AppendLogAsync(1, $"Concurrent log {i}"))
+                .ToList();
+
+            await Task.WhenAll(tasks);
+            await _service.FlushLogsAsync(1);
+
+            // Assert - All logs should be captured
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            itemInDb.Should().NotBeNull();
+            itemInDb!.PersistedLog.Should().NotBeNullOrEmpty();
+
+            var logLines = itemInDb.PersistedLog.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            logLines.Should().HaveCount(100);
+        }
+
+        #endregion
+
+        #region State Management Tests
+
+        [Fact]
+        public async Task UpdateItemStateAsync_UpdatesStatusCorrectly()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Paused
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act
+            await _service.UpdateItemStateAsync(1, EQueueItemStatus.Downloading);
+
+            // Assert
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            itemInDb.Should().NotBeNull();
+            itemInDb!.Status.Should().Be(EQueueItemStatus.Downloading);
+        }
+
+        [Fact]
+        public async Task CancelDownloadAsync_UpdatesStatusAndCancelsToken()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Downloading
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Get token source before cancelling
+            var tokenSource = _downloadStateService.GetOrAddTokenSource(1);
+
+            // Act
+            await _service.CancelDownloadAsync(1);
+
+            // Assert
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            itemInDb.Should().NotBeNull();
+            itemInDb!.Status.Should().Be(EQueueItemStatus.Cancelled);
+            tokenSource.IsCancellationRequested.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task CancelDownloadAsync_WithAlreadyCancelledItem_DoesNothing()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var item = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Cancelled
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(item);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act
+            await _service.CancelDownloadAsync(1);
+
+            // Assert
+            await using var verifyContext = new AppDbContext(_options);
+            var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
+
+            itemInDb.Should().NotBeNull();
+            itemInDb!.Status.Should().Be(EQueueItemStatus.Cancelled);
+        }
+
+        #endregion
+
+        #region Log Persistence Tests
+
+        [Fact]
+        public async Task GetQueueItemsAsync_DeserializesPersistedLogs()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var setupItem = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Finished,
+                    PersistedLog = $"Log 1{Environment.NewLine}Log 2{Environment.NewLine}Log 3"
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(setupItem);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act
+            var items = await _service.GetQueueItemsAsync();
+
+            // Assert
+            var resultItem = items.First();
+            resultItem.OutputLog.Should().HaveCount(3);
+            resultItem.OutputLog.Should().Contain("Log 1");
+            resultItem.OutputLog.Should().Contain("Log 2");
+            resultItem.OutputLog.Should().Contain("Log 3");
+        }
+
+        [Fact]
+        public async Task GetQueueItemByIdAsync_DeserializesPersistedLogs()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var setupItem = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Finished,
+                    PersistedLog = $"Line A{Environment.NewLine}Line B"
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(setupItem);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act
+            var resultItem = await _service.GetQueueItemByIdAsync(1);
+
+            // Assert
+            resultItem.Should().NotBeNull();
+            resultItem!.OutputLog.Should().HaveCount(2);
+            resultItem.OutputLog.Should().Contain("Line A");
+            resultItem.OutputLog.Should().Contain("Line B");
+        }
+
+        [Fact]
+        public async Task GetQueueItemByIdAsync_WithEmptyLogs_ReturnsEmptyList()
+        {
+            // Arrange
+            await using (var setupContext = new AppDbContext(_options))
+            {
+                var setupItem = new YoutubeDownloadQueueItem
+                {
+                    Id = 1,
+                    Url = "https://youtube.com/watch?v=test",
+                    Quality = "best",
+                    Proxy = "",
+                    Status = EQueueItemStatus.Paused,
+                    PersistedLog = ""
+                };
+
+                await setupContext.YoutubeDownloadQueueItems.AddAsync(setupItem);
+                await setupContext.SaveChangesAsync();
+            }
+
+            // Act
+            var resultItem = await _service.GetQueueItemByIdAsync(1);
+
+            // Assert
+            resultItem.Should().NotBeNull();
+            resultItem!.OutputLog.Should().BeEmpty();
+        }
+
+        #endregion
+    }
+}

--- a/SaveHere/SaveHere.Tests/Services/YoutubeDownloadQueueServiceTests.cs
+++ b/SaveHere/SaveHere.Tests/Services/YoutubeDownloadQueueServiceTests.cs
@@ -211,17 +211,32 @@ namespace SaveHere.Tests.Services
                 await setupContext.SaveChangesAsync();
             }
 
-            // Act - Append a single log line (should not trigger immediate DB write due to batching)
-            await _service.AppendLogAsync(1, "Test log line 1");
+            // First append triggers an immediate flush (since lastFlush starts at MinValue)
+            // This is expected behavior to ensure logs are persisted promptly on first write
+            await _service.AppendLogAsync(1, "First log line");
 
-            // Assert - The log should be queued but not immediately persisted
-            // (The first append within the flush interval doesn't trigger a flush)
+            // Wait a moment for the fire-and-forget flush to complete
+            await Task.Delay(100);
+
+            // Verify the first log was flushed
+            await using (var checkContext = new AppDbContext(_options))
+            {
+                var itemAfterFirst = await checkContext.YoutubeDownloadQueueItems.FindAsync(1);
+                itemAfterFirst.Should().NotBeNull();
+                itemAfterFirst!.PersistedLog.Should().Contain("First log line");
+            }
+
+            // Act - Now subsequent appends within the 5-second interval should be batched
+            await _service.AppendLogAsync(1, "Second log line");
+
+            // Assert - The second log should be queued but not immediately persisted
+            // (we're within the flush interval)
             await using var verifyContext = new AppDbContext(_options);
             var itemInDb = await verifyContext.YoutubeDownloadQueueItems.FindAsync(1);
 
-            // The log might not be persisted yet due to batching (5 second interval)
-            // This verifies the batching mechanism is working
             itemInDb.Should().NotBeNull();
+            // The second log should NOT be in the persisted log yet (batched in memory)
+            itemInDb!.PersistedLog.Should().NotContain("Second log line");
         }
 
         [Fact]

--- a/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadFromDirectLink.razor
@@ -366,6 +366,12 @@
 
   private List<ChartSeries> _speedSeries = new();
 
+  // Throttling for UI updates to prevent UI freezing
+  private DateTime _lastUiUpdateTime = DateTime.MinValue;
+  private readonly TimeSpan _uiUpdateInterval = TimeSpan.FromMilliseconds(500);
+  private DateTime _lastFileManagerRefreshTime = DateTime.MinValue;
+  private readonly TimeSpan _fileManagerRefreshInterval = TimeSpan.FromSeconds(2);
+
   protected override async Task OnInitializedAsync()
   {
     var authState = await AuthProvider.GetAuthenticationStateAsync();
@@ -468,6 +474,7 @@
     var item = _fileDownloadQueueItems.FirstOrDefault(x => x.Id == update.ItemId);
     if (item != null)
     {
+      // Always update the data
       item.ProgressPercentage = update.ProgressPercentage;
       item.CurrentDownloadSpeed = update.CurrentSpeed;
       item.AverageDownloadSpeed = update.AverageSpeed;
@@ -479,10 +486,21 @@
         item.SpeedHistory.RemoveAt(0);
       }
 
-      UpdateSpeedChart(item);
+      // Throttle UI updates to prevent freezing
+      var now = DateTime.UtcNow;
+      if (now - _lastUiUpdateTime >= _uiUpdateInterval)
+      {
+        _lastUiUpdateTime = now;
+        UpdateSpeedChart(item);
+        await InvokeAsync(StateHasChanged);
+      }
 
-      await RefreshFileManager();
-      await InvokeAsync(StateHasChanged);
+      // Throttle file manager refresh even more (expensive operation)
+      if (now - _lastFileManagerRefreshTime >= _fileManagerRefreshInterval)
+      {
+        _lastFileManagerRefreshTime = now;
+        await RefreshFileManager();
+      }
     }
     else
     {
@@ -496,15 +514,15 @@
     var item = _fileDownloadQueueItems.FirstOrDefault(x => x.Id == itemId);
     if (item != null)
     {
-      await InvokeAsync(() =>
+      item.Status = Enum.Parse<EQueueItemStatus>(newStatus);
+
+      // Refresh file manager when download completes or fails (not during active downloading)
+      if (newStatus != EQueueItemStatus.Downloading.ToString())
       {
-        item.Status = Enum.Parse<EQueueItemStatus>(newStatus);
-        if (newStatus != EQueueItemStatus.Downloading.ToString())
-        {
-          InvokeAsync(RefreshFileManager);
-        }
-        StateHasChanged();
-      });
+        await RefreshFileManager();
+      }
+
+      await InvokeAsync(StateHasChanged);
     }
     else
     {
@@ -555,7 +573,6 @@
   {
     if (!string.IsNullOrWhiteSpace(UrlText))
     {
-      var output = DownloadQueueService.GetFileInfo(UrlText);
       var parameters = new DialogParameters
             {
                 { "Url", UrlText },
@@ -568,6 +585,7 @@
         CloseButton = true
       };
 
+      // Show dialog immediately - the dialog will fetch file info asynchronously
       DialogService.Show<FileInfoDialog>("File Info", parameters, options);
     }
     else

--- a/SaveHere/SaveHere/Components/Download/DownloadVideoAudio.razor
+++ b/SaveHere/SaveHere/Components/Download/DownloadVideoAudio.razor
@@ -254,7 +254,9 @@
   private bool _isLoadingTheList = false;
 
   private DateTime _lastUiUpdateTime = DateTime.MinValue;
-  private TimeSpan _uiUpdateInterval = TimeSpan.FromSeconds(1);
+  private readonly TimeSpan _uiUpdateInterval = TimeSpan.FromMilliseconds(500);
+  private DateTime _lastFileManagerRefreshTime = DateTime.MinValue;
+  private readonly TimeSpan _fileManagerRefreshInterval = TimeSpan.FromSeconds(2);
 
   private bool _autoStartPausedDownloads = true;
   private int _maxAutoStartConcurrency = 3;
@@ -357,19 +359,22 @@
     var item = _youtubeDownloadQueueItems.FirstOrDefault(x => x.Id == itemId);
     if (item != null)
     {
-      await InvokeAsync(() =>
+      item.Status = Enum.Parse<EQueueItemStatus>(newStatus);
+
+      // Always update UI on state change, refresh file manager on completion/cancel
+      if (newStatus != EQueueItemStatus.Downloading.ToString())
       {
-        item.Status = Enum.Parse<EQueueItemStatus>(newStatus);
-        if (newStatus != EQueueItemStatus.Downloading.ToString())
-        {
-          ThrottleUIUpdate(true);
-        }
-      });
+        await ThrottleUIUpdateAsync(true);
+      }
+      else
+      {
+        await InvokeAsync(StateHasChanged);
+      }
     }
     else
     {
       await LoadDownloadItemsList();
-      ThrottleUIUpdate(true);
+      await ThrottleUIUpdateAsync(true);
     }
   }
 
@@ -378,17 +383,16 @@
     var item = _youtubeDownloadQueueItems.FirstOrDefault(x => x.Id == itemId);
     if (item != null)
     {
-      await InvokeAsync(() =>
-      {
-        item.OutputLog.Add(logLine);
-        ThrottleUIUpdate();
-      });
+      item.OutputLog.Add(logLine);
+      await ThrottleUIUpdateAsync();
+
+      // Queue log for batch append instead of immediate DB write
       await YoutubeDownloadQueueService.AppendLogAsync(itemId, logLine);
     }
     else
     {
       await LoadDownloadItemsList();
-      ThrottleUIUpdate(true);
+      await ThrottleUIUpdateAsync(true);
     }
   }
 
@@ -425,7 +429,7 @@
       YoutubeUrl = "";
       ErrorMessage = "";
       await LoadDownloadItemsList();
-      ThrottleUIUpdate();
+      await ThrottleUIUpdateAsync();
     }
     catch (Exception exception)
     {
@@ -472,7 +476,7 @@
     {
       await YoutubeDownloadQueueService.DeleteQueueItemAsync(item.Id);
       await LoadDownloadItemsList();
-      ThrottleUIUpdate(true);
+      await ThrottleUIUpdateAsync(true);
     }
     catch (Exception exception)
     {
@@ -503,14 +507,20 @@
     }
   }
 
-  private void ThrottleUIUpdate(bool forceUpdate = false)
+  private async Task ThrottleUIUpdateAsync(bool forceUpdate = false)
   {
-    var now = DateTime.Now;
+    var now = DateTime.UtcNow;
     if (forceUpdate || (now - _lastUiUpdateTime >= _uiUpdateInterval))
     {
       _lastUiUpdateTime = now;
-      InvokeAsync(StateHasChanged);
-      InvokeAsync(RefreshFileManager);
+      await InvokeAsync(StateHasChanged);
+    }
+
+    // File manager refresh is more expensive, throttle separately
+    if (forceUpdate || (now - _lastFileManagerRefreshTime >= _fileManagerRefreshInterval))
+    {
+      _lastFileManagerRefreshTime = now;
+      await RefreshFileManager();
     }
   }
 

--- a/SaveHere/SaveHere/Services/YoutubeDownloadQueueService.cs
+++ b/SaveHere/SaveHere/Services/YoutubeDownloadQueueService.cs
@@ -2,6 +2,7 @@
 using SaveHere.Models;
 using SaveHere.Models.db;
 using SaveHere.Models.SaveHere.Models;
+using System.Collections.Concurrent;
 
 namespace SaveHere.Services
 {
@@ -16,6 +17,7 @@ namespace SaveHere.Services
     Task StartDownloadAsync(YoutubeDownloadQueueItem item);
     Task CancelDownloadAsync(int id);
     Task AppendLogAsync(int itemId, string logLine);
+    Task FlushLogsAsync(int itemId);
   }
 
   public class YoutubeDownloadQueueService : IYoutubeDownloadQueueService
@@ -25,6 +27,11 @@ namespace SaveHere.Services
     private readonly ILogger<YoutubeDownloadQueueService> _logger;
     private readonly IProgressHubService _progressHubService;
     private readonly IYtdlpService _ytdlpService;
+
+    // Log batching: accumulate logs in memory and flush periodically
+    private readonly ConcurrentDictionary<int, ConcurrentQueue<string>> _pendingLogs = new();
+    private readonly ConcurrentDictionary<int, DateTime> _lastFlushTime = new();
+    private readonly TimeSpan _logFlushInterval = TimeSpan.FromSeconds(5);
 
     public YoutubeDownloadQueueService(
         IDbContextFactory<AppDbContext> contextFactory,
@@ -162,6 +169,7 @@ namespace SaveHere.Services
       try
       {
         // Clear previous logs when starting a new download
+        CleanupLogsForItem(item.Id);
         item.OutputLog.Clear();
         item.PersistedLog = string.Empty;
         item.Status = EQueueItemStatus.Downloading;
@@ -170,6 +178,9 @@ namespace SaveHere.Services
 
         await _ytdlpService.DownloadVideo(item.Id, item.Url, item.CustomFileName, item.Quality, item.Proxy, item.DownloadFolder,
          item.SubtitleLanguage, token);
+
+        // Flush any remaining logs before marking as finished
+        await FlushLogsAsync(item.Id);
 
         // Ensure we capture all logs before setting status to finished
         var currentLogs = item.OutputLog.ToList();
@@ -180,6 +191,7 @@ namespace SaveHere.Services
       }
       catch (OperationCanceledException)
       {
+        await FlushLogsAsync(item.Id);
         item.Status = EQueueItemStatus.Cancelled;
         item.PersistedLog = string.Join(Environment.NewLine, item.OutputLog);
         await UpdateItemStateAsync(item.Id, EQueueItemStatus.Cancelled);
@@ -188,6 +200,7 @@ namespace SaveHere.Services
       }
       catch (Exception ex)
       {
+        await FlushLogsAsync(item.Id);
         _logger.LogError(ex, "Error downloading video for item {id}: {message}", item.Id, ex.Message);
         item.Status = EQueueItemStatus.Paused;
         item.PersistedLog = string.Join(Environment.NewLine, item.OutputLog);
@@ -197,30 +210,84 @@ namespace SaveHere.Services
       }
       finally
       {
+        CleanupLogsForItem(item.Id);
         _downloadStateService.RemoveTokenSource(item.Id);
       }
     }
 
-    public async Task AppendLogAsync(int itemId, string logLine)
+    public Task AppendLogAsync(int itemId, string logLine)
+    {
+      // Add log to pending queue (in-memory, no DB hit)
+      var queue = _pendingLogs.GetOrAdd(itemId, _ => new ConcurrentQueue<string>());
+      queue.Enqueue(logLine);
+
+      // Check if we should flush based on time interval
+      var now = DateTime.UtcNow;
+      var lastFlush = _lastFlushTime.GetOrAdd(itemId, DateTime.MinValue);
+
+      if (now - lastFlush >= _logFlushInterval)
+      {
+        // Fire and forget the flush - don't await to avoid blocking
+        _ = FlushLogsAsync(itemId);
+      }
+
+      return Task.CompletedTask;
+    }
+
+    public async Task FlushLogsAsync(int itemId)
     {
       try
       {
+        if (!_pendingLogs.TryGetValue(itemId, out var queue) || queue.IsEmpty)
+        {
+          return;
+        }
+
+        // Drain all pending logs
+        var logsToFlush = new List<string>();
+        while (queue.TryDequeue(out var log))
+        {
+          logsToFlush.Add(log);
+        }
+
+        if (logsToFlush.Count == 0) return;
+
+        _lastFlushTime[itemId] = DateTime.UtcNow;
+
         await using var context = await _contextFactory.CreateDbContextAsync();
         var item = await context.YoutubeDownloadQueueItems.FindAsync(itemId);
         if (item != null)
         {
-          item.OutputLog = string.IsNullOrEmpty(item.PersistedLog)
-              ? new List<string> { logLine }
-              : item.PersistedLog.Split(Environment.NewLine).Concat(new[] { logLine }).ToList();
+          // Append all new logs at once
+          var existingLogs = string.IsNullOrEmpty(item.PersistedLog)
+              ? new List<string>()
+              : item.PersistedLog.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).ToList();
 
-          item.PersistedLog = string.Join(Environment.NewLine, item.OutputLog);
-          await context.SaveChangesAsync();
+          existingLogs.AddRange(logsToFlush);
+          item.PersistedLog = string.Join(Environment.NewLine, existingLogs);
+          item.OutputLog = existingLogs;
+
+          try
+          {
+            await context.SaveChangesAsync();
+          }
+          catch (DbUpdateConcurrencyException)
+          {
+            // Ignore concurrency conflicts for logs
+            context.Entry(item).State = EntityState.Detached;
+          }
         }
       }
       catch (Exception ex)
       {
-        _logger.LogError(ex, "Error appending log to database for item {itemId}: {Message}", itemId, ex.Message);
+        _logger.LogError(ex, "Error flushing logs to database for item {itemId}: {Message}", itemId, ex.Message);
       }
+    }
+
+    private void CleanupLogsForItem(int itemId)
+    {
+      _pendingLogs.TryRemove(itemId, out _);
+      _lastFlushTime.TryRemove(itemId, out _);
     }
 
   }

--- a/SaveHere/SaveHere/Services/YoutubeDownloadQueueService.cs
+++ b/SaveHere/SaveHere/Services/YoutubeDownloadQueueService.cs
@@ -31,6 +31,7 @@ namespace SaveHere.Services
     // Log batching: accumulate logs in memory and flush periodically
     private readonly ConcurrentDictionary<int, ConcurrentQueue<string>> _pendingLogs = new();
     private readonly ConcurrentDictionary<int, DateTime> _lastFlushTime = new();
+    private readonly ConcurrentDictionary<int, SemaphoreSlim> _flushLocks = new();
     private readonly TimeSpan _logFlushInterval = TimeSpan.FromSeconds(5);
 
     public YoutubeDownloadQueueService(
@@ -236,6 +237,14 @@ namespace SaveHere.Services
 
     public async Task FlushLogsAsync(int itemId)
     {
+      var flushLock = _flushLocks.GetOrAdd(itemId, _ => new SemaphoreSlim(1, 1));
+
+      // If a flush is already in progress for this item, skip this call
+      if (!await flushLock.WaitAsync(0))
+      {
+        return;
+      }
+
       try
       {
         if (!_pendingLogs.TryGetValue(itemId, out var queue) || queue.IsEmpty)
@@ -271,9 +280,15 @@ namespace SaveHere.Services
           {
             await context.SaveChangesAsync();
           }
-          catch (DbUpdateConcurrencyException)
+          catch (DbUpdateConcurrencyException ex)
           {
-            // Ignore concurrency conflicts for logs
+            _logger.LogWarning(ex, "Concurrency conflict during log flush for item {itemId}. Re-queuing {LogCount} logs to prevent data loss.", itemId, logsToFlush.Count);
+            // Re-queue the logs that failed to persist
+            foreach (var log in logsToFlush)
+            {
+              queue.Enqueue(log);
+            }
+            // Detach the entity to resolve the conflict for this context instance
             context.Entry(item).State = EntityState.Detached;
           }
         }
@@ -282,12 +297,20 @@ namespace SaveHere.Services
       {
         _logger.LogError(ex, "Error flushing logs to database for item {itemId}: {Message}", itemId, ex.Message);
       }
+      finally
+      {
+        flushLock.Release();
+      }
     }
 
     private void CleanupLogsForItem(int itemId)
     {
       _pendingLogs.TryRemove(itemId, out _);
       _lastFlushTime.TryRemove(itemId, out _);
+      if (_flushLocks.TryRemove(itemId, out var semaphore))
+      {
+        semaphore.Dispose();
+      }
     }
 
   }

--- a/SaveHere/SaveHere/Services/YtdlpService.cs
+++ b/SaveHere/SaveHere/Services/YtdlpService.cs
@@ -3,6 +3,7 @@ using SaveHere.Models;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Threading.Channels;
 
 namespace SaveHere.Services
 {
@@ -276,20 +277,31 @@ namespace SaveHere.Services
 
       using var process = new Process { StartInfo = startInfo };
 
-      process.OutputDataReceived += async (sender, e) =>
+      // Use a channel to properly handle async log processing
+      var logChannel = Channel.CreateUnbounded<string>(new UnboundedChannelOptions
+      {
+        SingleReader = true,
+        SingleWriter = false
+      });
+
+      // Track pending log broadcasts
+      var logProcessingTask = ProcessLogChannelAsync(logChannel.Reader, itemId, cancellationToken);
+
+      process.OutputDataReceived += (sender, e) =>
       {
         if (!string.IsNullOrEmpty(e.Data))
         {
-          await _progressHubService.BroadcastLogUpdate(itemId, e.Data);
+          // Write to channel synchronously (non-blocking)
+          logChannel.Writer.TryWrite(e.Data);
         }
       };
 
-      process.ErrorDataReceived += async (sender, e) =>
+      process.ErrorDataReceived += (sender, e) =>
       {
         if (!string.IsNullOrEmpty(e.Data))
         {
           string errorLog = $"Error: {e.Data}";
-          await _progressHubService.BroadcastLogUpdate(itemId, errorLog);
+          logChannel.Writer.TryWrite(errorLog);
           _logger.LogWarning("yt-dlp error: {Error}", e.Data);
         }
       };
@@ -301,6 +313,12 @@ namespace SaveHere.Services
       try
       {
         await process.WaitForExitAsync(cancellationToken);
+
+        // Signal that no more logs are coming
+        logChannel.Writer.Complete();
+
+        // Wait for all logs to be processed before continuing
+        await logProcessingTask;
 
         if (process.ExitCode != 0)
         {
@@ -314,6 +332,7 @@ namespace SaveHere.Services
       }
       catch (OperationCanceledException)
       {
+        logChannel.Writer.TryComplete();
         await _progressHubService.BroadcastStateChange(itemId, EQueueItemStatus.Cancelled.ToString());
         await _progressHubService.BroadcastLogUpdate(itemId, "Download was cancelled.");
         if (!process.HasExited)
@@ -324,10 +343,37 @@ namespace SaveHere.Services
       }
       catch (Exception ex)
       {
+        logChannel.Writer.TryComplete();
         string exceptionError = $"Download failed: {ex.Message}";
         await _progressHubService.BroadcastStateChange(itemId, EQueueItemStatus.Paused.ToString());
         await _progressHubService.BroadcastLogUpdate(itemId, exceptionError);
         throw;
+      }
+    }
+
+    private async Task ProcessLogChannelAsync(ChannelReader<string> reader, int itemId, CancellationToken cancellationToken)
+    {
+      try
+      {
+        await foreach (var logLine in reader.ReadAllAsync(cancellationToken))
+        {
+          try
+          {
+            await _progressHubService.BroadcastLogUpdate(itemId, logLine);
+          }
+          catch (Exception ex)
+          {
+            _logger.LogWarning(ex, "Failed to broadcast log update for item {ItemId}", itemId);
+          }
+        }
+      }
+      catch (OperationCanceledException)
+      {
+        // Expected when download is cancelled
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Error processing log channel for item {ItemId}", itemId);
       }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the UI freezing/unresponsiveness issue reported in #54 where components become unresponsive while downloading, particularly with multiple YouTube downloads.

### Root Causes Identified
- Excessive UI re-renders (unbounded `StateHasChanged` calls on every progress update)
- Database writes on every log line during YouTube downloads (100+ writes per download)
- Fire-and-forget async event handlers in yt-dlp process output handling
- Un-awaited `InvokeAsync` calls causing update queue buildup
- File manager refresh triggered on every progress update (expensive operation)

### Changes Made

**UI Components (`DownloadFromDirectLink.razor`, `DownloadVideoAudio.razor`):**
- Added UI update throttling (500ms intervals) to limit `StateHasChanged` calls
- Added file manager refresh throttling (2 second intervals)
- Fixed un-awaited `InvokeAsync` calls
- Fixed nested `InvokeAsync` patterns

**YoutubeDownloadQueueService:**
- Implemented log batching using `ConcurrentQueue` - logs are queued in memory and flushed to database every 5 seconds instead of on every log line
- Added `FlushLogsAsync()` method for explicit flushing on download completion
- Reduces database writes from 100+/download to ~5-10/download

**YtdlpService:**
- Replaced fire-and-forget `async void` event handlers with proper `Channel<T>`-based log processing
- Process output/error events now write to a channel synchronously (non-blocking)
- A dedicated task reads from the channel and properly awaits SignalR broadcasts
- Ensures all logs are processed before download completion is signaled

### Performance Improvements

| Metric | Before | After |
|--------|--------|-------|
| UI renders | Unbounded (~1/sec/download) | Max 2/sec total |
| DB writes (logs) | Every log line (100+/download) | Batched every 5s (~5-10/download) |
| File manager refresh | Every progress update | Every 2 seconds |

### Tests Added
- 20 new unit tests for `YoutubeDownloadQueueService`
- Includes thread safety test with 100 concurrent log appends
- Tests for log batching, flushing, and persistence

## Test Plan
- [x] Build succeeds with no new errors
- [x] All 128 unit tests pass
- [ ] Manual test: Start 3+ YouTube downloads simultaneously and verify UI remains responsive
- [ ] Manual test: Verify download logs are captured correctly after completion
- [ ] Manual test: Verify progress updates still display (with slight delay due to throttling)

Fixes #54